### PR TITLE
Add new repositories

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -56,6 +56,13 @@ repos:
 - name: regulations-site
   description: Display the regulations
   url: https://github.com/cfpb/regulations-site
+- name: regulations-bootstrap
+  description: Bootstrap eRegulations
+  url: https://github.com/cfpb/regulations-bootstrap
+- name: regulations-stub
+  description: Pre-parsed regulations
+  url: https://github.com/cfpb/regulations-stub
+    
 
 # Style Variables
 brand_color: "#2cb34a"

--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,9 @@ navigation:
 - text: Technology
   url: '#technology'
   internal: true
+- text: Getting Started
+  url: '#getting-started'
+  internal: true
 - text: Open Source Contributing
   url: '#open-source-and-contributing'
   internal: true
@@ -56,13 +59,19 @@ repos:
 - name: regulations-site
   description: Display the regulations
   url: https://github.com/cfpb/regulations-site
+
+support_repos:
 - name: regulations-bootstrap
   description: Bootstrap eRegulations
   url: https://github.com/cfpb/regulations-bootstrap
+
+cfpb_repos:
 - name: regulations-stub
-  description: Pre-parsed regulations
+  description: Parsed CFPB regulations
   url: https://github.com/cfpb/regulations-stub
-    
+- name: fr-notices
+  description: XML for CFPB regulations
+  url: https://github.com/cfpb/fr-notices
 
 # Style Variables
 brand_color: "#2cb34a"

--- a/_includes/index.md
+++ b/_includes/index.md
@@ -46,6 +46,13 @@ regulations-core is a Django and Haystack application.
 
 The regulations-site front-end is a Backbone.js application using Browserify. We also use a Grunt-based build system with Mocha for unit testing. On the back-end, regulations-site is a Django application.
 
+## Getting Started
+
+The best way to get started with eRegulations is via 
+[regulations-bootstrap](https://github.com/cfpb/regulations-bootstrap).
+This repository contains scripts that will setup a working copy of
+eRegulations either locally or in a virtual machine. 
+
 ## Open Source and Contributing
 
 We invite contributions to any part of the application. The project is in the public domain, and all contributions to it will be released as such. By submitting a pull request, you are agreeing to waive all rights to your contribution under the terms of the [CC0 Public Domain Dedication](http://creativecommons.org/publicdomain/zero/1.0/).

--- a/_includes/repos.md
+++ b/_includes/repos.md
@@ -4,7 +4,7 @@
 There are many individual repositories that make up eRegulations. These are divided below into the main body of eRegulations, tools to support eRegulations, and finally CFPB-specific modifications and data for eRegulations.
 
 {% if site.repos %}
-<section id="repositories">
+<section id="main-repositories">
   <h3 id="repositories">eRegulations</h3>
   <ul class="repo-list group">
     <li class="list-icon">
@@ -23,7 +23,7 @@ There are many individual repositories that make up eRegulations. These are divi
 {% endif %}
 
 {% if site.support_repos %}
-<section id="repositories">
+<section id="support-repositories">
   <h3 id="repositories">Support</h3>
   <ul class="repo-list group">
     <li class="list-icon">
@@ -42,7 +42,7 @@ There are many individual repositories that make up eRegulations. These are divi
 {% endif %}
 
 {% if site.cfpb_repos %}
-<section id="repositories">
+<section id="cfpb-repositories">
   <h3 id="repositories">CFPB-Specific</h3>
   <ul class="repo-list group">
     <li class="list-icon">

--- a/_includes/repos.md
+++ b/_includes/repos.md
@@ -1,0 +1,62 @@
+
+## Repositories
+
+There are many individual repositories that make up eRegulations. These are divided below into the main body of eRegulations, tools to support eRegulations, and finally CFPB-specific modifications and data for eRegulations.
+
+{% if site.repos %}
+<section id="repositories">
+  <h3 id="repositories">eRegulations</h3>
+  <ul class="repo-list group">
+    <li class="list-icon">
+      <img src="assets/img/octocat.png" width="25px" alt="">
+    </li>
+    {% for repo in site.repos %}
+      <li>
+        <a href="{{ repo.url }}">
+          <h4>{{ repo.name }}</h4>
+          <p>{{ repo.description }}</p>
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+</section>
+{% endif %}
+
+{% if site.support_repos %}
+<section id="repositories">
+  <h3 id="repositories">Support</h3>
+  <ul class="repo-list group">
+    <li class="list-icon">
+      <img src="assets/img/octocat.png" width="25px" alt="">
+    </li>
+    {% for repo in site.support_repos %}
+      <li>
+        <a href="{{ repo.url }}">
+          <h4>{{ repo.name }}</h4>
+          <p>{{ repo.description }}</p>
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+</section>
+{% endif %}
+
+{% if site.cfpb_repos %}
+<section id="repositories">
+  <h3 id="repositories">CFPB-Specific</h3>
+  <ul class="repo-list group">
+    <li class="list-icon">
+      <img src="assets/img/octocat.png" width="25px" alt="">
+    </li>
+    {% for repo in site.cfpb_repos %}
+      <li>
+        <a href="{{ repo.url }}">
+          <h4>{{ repo.name }}</h4>
+          <p>{{ repo.description }}</p>
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+</section>
+{% endif %}
+

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -389,6 +389,10 @@ ul.repo-list {
 
 .repo-list li {
     list-style: none;
+    margin-bottom: 0;
+    height: 4.0625em;
+    max-height: 4.0625em;
+    background-color: #E7E7E6;
 }
 
 .repo-list p {
@@ -399,6 +403,27 @@ ul.repo-list {
 .repo-list h4 {
     text-transform: none;
 }
+
+.repo-list a:link,
+.repo-list a:visited {
+    display: block;
+    max-height: 4.0625em;
+    background-color: #E7E7E6;
+    padding: .625em 1em 1em 1em;
+    border-bottom: none;
+}
+
+.repo-list a:hover {
+    color: #4D5F87;
+    background-color: #CDE3F1;
+}
+
+.repo-list li:first-child {
+    text-align: center;
+    line-height: 60px;
+    padding: .625em 1em;
+}
+
 
 /*
 Helper Classes
@@ -473,37 +498,18 @@ Desktop Styles
     Repo list
     ------------------------------
     */
+}
+
+@media screen and (min-width: 54.375em) and (min-height: 32.5em) {
 
     .repo-list li {
-        list-style: none;
-        display: block;
         float: left;
-        height: 4.0625em;
-        max-height: 4.0625em;
-        background-color: #E7E7E6;
         border-left: 1px solid #BABBBD;
         width: 30%;
     }
 
-    .repo-list a:link,
-    .repo-list a:visited {
-        display: block;
-        max-height: 4.0625em;
-        background-color: #E7E7E6;
-        border-bottom: none;
-        padding: .625em 1em 1em 1em;
-    }
-
-    .repo-list a:hover {
-        color: #4D5F87;
-        background-color: #CDE3F1;
-    }
-
     .repo-list li:first-child {
-        text-align: center;
         border-left: none;
-        line-height: 60px;
-        padding: .625em 1em;
         width: 10%;
     }
 
@@ -514,14 +520,24 @@ Desktop Styles
     /* keep the repo list containers the same height, but account for the need for more height */
 
     .repo-list li {
-        height: 6em;
-        max-height: 6em;
+        float: none;
+        border-top: 1px solid #BABBBD;
     }
 
     .repo-list a:link,
     .repo-list a:visited {
-        max-height: 6em;
+        border-bottom: none;
     }
+
+    .repo-list a:hover {
+        color: #4D5F87;
+        background-color: #CDE3F1;
+    }
+
+    .repo-list li:first-child {
+        border-top: none;
+    }
+
 }
 
 /*
@@ -533,6 +549,24 @@ Mobile Styles
 
     .main-content {
         margin-top: 1.5em;
+    }
+
+    .repo-list li {
+        border-top: 1px solid #BABBBD;
+    }
+
+    .repo-list a:link,
+    .repo-list a:visited {
+        border-bottom: none;
+    }
+
+    .repo-list a:hover {
+        color: #4D5F87;
+        background-color: #CDE3F1;
+    }
+
+    .repo-list li:first-child {
+        border-top: none;
     }
 
 }

--- a/index.html
+++ b/index.html
@@ -6,24 +6,8 @@ title: eRegulations
 {% capture intro %}{% include intro.md %}{% endcapture %}
 {{ intro | markdownify }}
 
-{% if site.repos %}
-<section id="repositories">
-  <h2 id="repositories">Repositories</h2>
-  <ul class="repo-list group">
-    <li class="list-icon">
-      <img src="assets/img/octocat.png" width="25px" alt="">
-    </li>
-    {% for repo in site.repos %}
-      <li>
-        <a href="{{ repo.url }}">
-          <h4>{{ repo.name }}</h4>
-          <p>{{ repo.description }}</p>
-        </a>
-      </li>
-    {% endfor %}
-  </ul>
-</section>
-{% endif %}
+{% capture repos %}{% include repos.md %}{% endcapture %}
+{{ repos | markdownify }}
 
 {% capture index %}{% include index.md %}{% endcapture %}
 {{ index | markdownify }}


### PR DESCRIPTION
This PR adds the new(ish) repositories to the list of repos and adds a brief "getting started" section that points people to regulations-bootstrap. The changes can [be viewed in my fork](https://willbarton.github.io/eRegulations/).

It also makes the repository lists slightly more responsive. On smaller screens: 

<img width="256" alt="small_fixed" src="https://cloud.githubusercontent.com/assets/10562538/8579893/470f7ed0-2585-11e5-9591-ceda230b62a6.png"> 

As opposed to:

<img width="256" alt="small_notfixed" src="https://cloud.githubusercontent.com/assets/10562538/8579906/651c070e-2585-11e5-8450-b65e6742000a.png">
