### PR TITLE
Add "Live Instances", split "Technology" into it's own page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 eRegulations Documentation
 ============
 
-[eRegulations](http://www.consumerfinance.gov/eregulations/) is a web-based tool that makes regulations easier to find, read and understand with features such as inline official interpretations, highlighted defined terms, and a revision comparison view. This repository contains documentation for the project and can be viewed at <http://cfpb.github.io/eRegulations>
+eRegulations is a web-based tool that makes regulations easier to find, read
+and understand with features such as inline official interpretations,
+highlighted defined terms, and a revision comparison view. This repository
+contains companion documentation for the project and can be viewed at
+<http://eregs.github.io/eRegulations>
 
 ## Editing the documentation
 
-The documentation uses [Jekyll](http://jekyllrb.com/) and our [DOCter](https://github.com/cfpb/DOCter) theme.
+The documentation uses [Jekyll](http://jekyllrb.com/) and the [DOCter](https://github.com/cfpb/DOCter) theme.
 
 DOCter needs Jekyll and other dependencies to run locally. These can be installed with Bundler by running the following commands.
 
@@ -14,12 +18,6 @@ gem install bundler
 bundle install
 ```
 
-Fork and clone the repo:
-
-```
-git clone git@github.com:cfpb/DOCter.git
-cd DOCter
-```
 Run Jekyll:
 
 ```
@@ -31,4 +29,5 @@ Open it up in your browser: <http://localhost:4000/>
 
 ### _config.yml
 
-Options within the `_config.yml` file allow you to control the site's title, subtitle, logo, author information, and the left column navigation.
+Options within the `_config.yml` file allow you to control some of the site's
+content and left column navigation.

--- a/_config.yml
+++ b/_config.yml
@@ -34,24 +34,11 @@ navigation:
 - text: Live Instances
   url: '#live-instances'
   internal: true
-- text: Repositories
-  url: '#repositories'
-  internal: true
 - text: Features
   url: '#features'
   internal: true
-- text: Architecture
-  url: '#architecture'
-  internal: true
 - text: Technology
-  url: '#technology'
-  internal: true
-- text: Getting Started
-  url: '#getting-started'
-  internal: true
-- text: Open Source Contributing
-  url: '#open-source-and-contributing'
-  internal: true
+  url: '/technology/'
 
 
 # Repo list

--- a/_config.yml
+++ b/_config.yml
@@ -31,6 +31,9 @@ logoalt: Consumer Financial Protection Bureau
 # Navigation
 # List links that should appear in the site sidebar here
 navigation:
+- text: Live Instances
+  url: '#live-instances'
+  internal: true
 - text: Repositories
   url: '#repositories'
   internal: true
@@ -79,3 +82,12 @@ cfpb_repos:
 
 # Style Variables
 brand_color: "#2cb34a"
+
+# eRegs instances in the while
+instances:
+- url: http://www.consumerfinance.gov/eregulations/
+  title: 12
+  agency: Consumer Financial Protection Bureau
+- url: https://atf-eregs.apps.cloud.gov/
+  title: 27
+  agency: Bureau of Alcohol, Tobacco, Firearms and Explosives

--- a/_includes/index.md
+++ b/_includes/index.md
@@ -32,30 +32,8 @@ The notices that compose a version of the regulation contain relevant analyses o
 - #### RESPONSIVE DESIGN.
 The application design is responsive, adjusting to the device and screen size of the user.
 
-## Architecture
-
-There are three parts to the eRegulations application: a parser that converts regulation text into data ([regulations-parser](https://github.com/cfpb/regulations-parser)), an API that hosts this data ([regulations-core](https://github.com/cfpb/regulations-core)), and a webapp which uses the data from the API to construct beautiful and usable regulations ([regulations-site](https://github.com/cfpb/regulations-site)).
-
-One would typically run the parser against a regulation once (for each version) to populate the API with all the necessary data. regulations-site would then use regulations-core to as necessary to display regulations.
-
-## Technology
-
-regulations-parser is written in Python.
-
-regulations-core is a Django and Haystack application.
-
-The regulations-site front-end is a Backbone.js application using Browserify. We also use a Grunt-based build system with Mocha for unit testing. On the back-end, regulations-site is a Django application.
-
-## Getting Started
-
-The best way to get started with eRegulations is via 
-[regulations-bootstrap](https://github.com/cfpb/regulations-bootstrap).
-This repository contains scripts that will setup a working copy of
-eRegulations either locally or in a virtual machine. 
-
 ## Open Source and Contributing
 
 We invite contributions to any part of the application. The project is in the public domain, and all contributions to it will be released as such. By submitting a pull request, you are agreeing to waive all rights to your contribution under the terms of the [CC0 Public Domain Dedication](http://creativecommons.org/publicdomain/zero/1.0/).
 
 If you contribute the open source work of others, please mark it clearly in your pull request.
-

--- a/_includes/instances.md
+++ b/_includes/instances.md
@@ -1,0 +1,18 @@
+## Live Instances
+
+The application is typically hosted by individual federal agencies, with
+features, branding, etc. unique to their users and needs. Current instances of
+eRegs include:
+
+<section>
+  <ul class="group">
+    {% for instance in site.instances %}
+      <li>
+        <a href="{{ instance.url }}">
+          <h4>CFR {{ instance.title }}</h4>
+          <p>{{ instance.agency }}</p>
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+</section>

--- a/_includes/technology/architecture.md
+++ b/_includes/technology/architecture.md
@@ -1,0 +1,7 @@
+## Architecture
+
+There are three parts to the eRegulations application: a parser that converts regulation text into data ([regulations-parser](https://github.com/cfpb/regulations-parser)), an API that hosts this data ([regulations-core](https://github.com/cfpb/regulations-core)), and a webapp which uses the data from the API to construct beautiful and usable regulations ([regulations-site](https://github.com/cfpb/regulations-site)).
+
+One would typically run the parser against a regulation once (for each version) to populate the API with all the necessary data. regulations-site would then use regulations-core to as necessary to display regulations.
+
+

--- a/_includes/technology/getting-started.md
+++ b/_includes/technology/getting-started.md
@@ -1,0 +1,8 @@
+## Getting Started
+
+The best way to get started with eRegulations is via 
+[regulations-bootstrap](https://github.com/cfpb/regulations-bootstrap).
+This repository contains scripts that will setup a working copy of
+eRegulations either locally or in a virtual machine. 
+
+

--- a/_includes/technology/repos.md
+++ b/_includes/technology/repos.md
@@ -8,7 +8,7 @@ There are many individual repositories that make up eRegulations. These are divi
   <h3 id="repositories">eRegulations</h3>
   <ul class="repo-list group">
     <li class="list-icon">
-      <img src="assets/img/octocat.png" width="25px" alt="">
+      <img src="../assets/img/octocat.png" width="25px" alt="">
     </li>
     {% for repo in site.repos %}
       <li>
@@ -27,7 +27,7 @@ There are many individual repositories that make up eRegulations. These are divi
   <h3 id="repositories">Support</h3>
   <ul class="repo-list group">
     <li class="list-icon">
-      <img src="assets/img/octocat.png" width="25px" alt="">
+      <img src="../assets/img/octocat.png" width="25px" alt="">
     </li>
     {% for repo in site.support_repos %}
       <li>
@@ -46,7 +46,7 @@ There are many individual repositories that make up eRegulations. These are divi
   <h3 id="repositories">CFPB-Specific</h3>
   <ul class="repo-list group">
     <li class="list-icon">
-      <img src="assets/img/octocat.png" width="25px" alt="">
+      <img src="../assets/img/octocat.png" width="25px" alt="">
     </li>
     {% for repo in site.cfpb_repos %}
       <li>

--- a/_includes/technology/stack.md
+++ b/_includes/technology/stack.md
@@ -1,0 +1,9 @@
+## Stack
+
+regulations-parser is written in Python 2.8.
+
+regulations-core is a Django and Haystack application.
+
+The regulations-site front-end is a Backbone.js application using Browserify. We also use a Grunt-based build system with Mocha for unit testing. On the back-end, regulations-site is a Django application.
+
+

--- a/_pages/technology.html
+++ b/_pages/technology.html
@@ -1,10 +1,13 @@
 ---
 layout: default
-subtemplates: [intro, instances, index]
+title: Technology
+subtemplates: [architecture, stack, repos, getting-started]
 ---
+<h1>Technology</h1>
 
 {% for subtemplate in page.subtemplates %}
-  {% capture subtemplate_file %}{{subtemplate}}.md{% endcapture %}
+  {% capture subtemplate_file %}technology/{{subtemplate}}.md{% endcapture %}
   {% capture markdown %}{% include {{subtemplate_file}} %}{% endcapture %}
   {{ markdown | markdownify }}
 {% endfor %}
+

--- a/index.html
+++ b/index.html
@@ -1,12 +1,10 @@
 ---
 layout: default
+subtemplates: [intro, repos, index]
 ---
 
-{% capture intro %}{% include intro.md %}{% endcapture %}
-{{ intro | markdownify }}
-
-{% capture repos %}{% include repos.md %}{% endcapture %}
-{{ repos | markdownify }}
-
-{% capture index %}{% include index.md %}{% endcapture %}
-{{ index | markdownify }}
+{% for subtemplate in page.subtemplates %}
+  {% capture subtemplate_file %}{{subtemplate}}.md{% endcapture %}
+  {% capture markdown %}{% include {{subtemplate_file}} %}{% endcapture %}
+  {{ markdown | markdownify }}
+{% endfor %}

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-subtemplates: [intro, repos, index]
+subtemplates: [intro, instances, repos, index]
 ---
 
 {% for subtemplate in page.subtemplates %}


### PR DESCRIPTION
This is prep for a following PR which will expand on the repositories section, which will include 18f repos and the now-shared fr-notices repo.

See individual changesets for details. Looks like: http://cmc333333.github.io/eRegulations/
