### PR TITLE
List more repos, make less CFPB-centric

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,15 +19,6 @@ subtitle: Making regulations easily readable, accessible, and understandable.
 #baseurl: ''
 baseurl: '/eRegulations'
 
-# Author/Organization info to be displayed in the templates
-author:
-  name: CFPB
-  url: http://cfpb.github.io/
-
-# Point the logo URL at a file in your repo or hosted elsewhere by your organization
-logourl: http://cfpb.github.io/img/logo_210.png
-logoalt: Consumer Financial Protection Bureau
-
 # Navigation
 # List links that should appear in the site sidebar here
 navigation:

--- a/_config.yml
+++ b/_config.yml
@@ -42,31 +42,98 @@ navigation:
   internal: true
 
 
-# Repo list
-# List repos that you would like to appear on the homepage here
-repos:
-- name: regulations-parser
-  description: Parse regulations
-  url: https://github.com/cfpb/regulations-parser
-- name: regulations-core
-  description: Regulations API
-  url: https://github.com/cfpb/regulations-core
-- name: regulations-site
-  description: Display the regulations
-  url: https://github.com/cfpb/regulations-site
+general_repos:
+  - name: regulations-parser
+    url: https://github.com/18F/regulations-parser
+    short: Parse regulations
+    long: >
+      The parser effectively converts print-centric documents from the Federal
+      Register, Government Printing Office, etc., pulls out semantic meaning
+      from them (e.g. paragraph structures, citations, definitions), and
+      writes those structures to a data store. The parser also contains tools
+      to help developers debug this process.
+  - name: regulations-core
+    url: https://github.com/18F/regulations-core
+    short: Regulations API
+    long: The store for the parsed regulatory data.
+  - name: regulations-site
+    url: https://github.com/18F/regulations-site
+    short: Display the regulations
+    long: >
+      An intuitive, responsive UI for viewing the regulations. It combines all
+      of the parsed data into an interface, providing in-line access to
+      definitions, citations, external material and more. This is the primary
+      use case for the regulatory data.
+  - name: fr-notices
+    url: https://github.com/eregs/fr-notices
+    short: Edited source XML
+    long: >
+      Often, source files will need to be massaged and modified to fit the
+      parser's limited understanding. This repository is a canonical source
+      for these edits, across all agencies, so that developers remain in sync.
+  - name: eRegulations
+    url: https://github.com/eregs/eRegulations
+    short: Documentation
+    long: The content for these HTML pages.
 
-support_repos:
-- name: regulations-bootstrap
-  description: Bootstrap eRegulations
-  url: https://github.com/cfpb/regulations-bootstrap
-
-cfpb_repos:
-- name: regulations-stub
-  description: Parsed CFPB regulations
-  url: https://github.com/cfpb/regulations-stub
-- name: fr-notices
-  description: XML for CFPB regulations
-  url: https://github.com/cfpb/fr-notices
+agency_repos:
+  - name: Consumer Financial Protection Bureau
+    repos:
+    - name: regulations-parser
+      url: https://github.com/cfpb/regulations-parser
+      short: Parse regulations
+      long: >
+        The parser effectively converts print-centric documents from the Federal
+        Register, Government Printing Office, etc., pulls out semantic meaning
+        from them (e.g. paragraph structures, citations, definitions), and
+        writes those structures to a data store. The parser also contains tools
+        to help developers debug this process.
+    - name: regulations-core
+      url: https://github.com/cfpb/regulations-core
+      short: Regulations API
+      long: The store for the parsed regulatory data.
+    - name: regulations-site
+      url: https://github.com/cfpb/regulations-site
+      short: Display the regulations
+      long: >
+        An intuitive, responsive UI for viewing the regulations. It combines all
+        of the parsed data into an interface, providing in-line access to
+        definitions, citations, external material and more. This is the primary
+        use case for the regulatory data.
+    - name: regulations-bootstrap
+      url: https://github.com/cfpb/regulations-bootstrap
+      short: Vagrant for quick setup
+      long: >
+        Vagrant files for quickly setting up a virtual machine in preparation
+        for working with CFPB eRegs repositories.
+    - name: regulations-schema
+      url: https://github.com/cfpb/regulations-schema
+      short: Regulation XML schema
+      long: >
+        An experimental XML schema for defining regulations. Regulations in this
+        format could then be maintained by only editing a single XML file,
+        rather than worrying about external sources of data. Currently,
+        CFPB-centric.
+    - name: regulations-xml-parser
+      url: https://github.com/cfpb/regulations-xml-parser
+      short: Schema -> JSON for regulations
+      long: >
+        A companion to regulations-schema which takes XML following that
+        schema and converts it into the format accepted by regulations-core.
+    - name: regulations-stub
+      url: https://github.com/cfpb/regulations-stub
+      short: Parsed CFPB regulations
+      long: >
+        A cached set of CFPB regulations as JSON files, ready for importing
+        into regulations-core.
+  - name: Bureau of Alcohol, Tobacco, Firearms and Explosives
+    repos:
+    - name: atf-eregs
+      url: https://github.com/18F/atf-eregs
+      short: ATF UI Elements
+      long: >
+        Static assets, deployment configuration, and UI plugins specific to
+        ATF's instance of eRegulations.
 
 # Style Variables
 brand_color: "#2cb34a"

--- a/_includes/intro.md
+++ b/_includes/intro.md
@@ -1,2 +1,5 @@
-[eRegulations](http://www.consumerfinance.gov/eregulations) is a web-based application that makes regulations easier to find, read and understand. It is a work in progress by the [Consumer Financial Protection Bureau](http://consumerfinance.gov/), and is a public domain work of the United States Government.
+eRegulations is a web-based application that makes regulations easier to find,
+read and understand. It is a work in progress by the [Consumer Financial Protection Bureau](http://consumerfinance.gov/)
+and [18F](https://18f.gsa.gov/). It is a public domain work of the United
+States Government.
 

--- a/_includes/technology/architecture.md
+++ b/_includes/technology/architecture.md
@@ -1,6 +1,6 @@
 ## Architecture
 
-There are three parts to the eRegulations application: a parser that converts regulation text into data ([regulations-parser](https://github.com/cfpb/regulations-parser)), an API that hosts this data ([regulations-core](https://github.com/cfpb/regulations-core)), and a webapp which uses the data from the API to construct beautiful and usable regulations ([regulations-site](https://github.com/cfpb/regulations-site)).
+There are three primary parts to the eRegulations application: a parser that converts regulation text into data (regulations-parser), an API that hosts this data (regulations-core), and a webapp which uses the data from the API to construct beautiful and usable regulations (regulations-site).
 
 One would typically run the parser against a regulation once (for each version) to populate the API with all the necessary data. regulations-site would then use regulations-core to as necessary to display regulations.
 

--- a/_includes/technology/getting-started.md
+++ b/_includes/technology/getting-started.md
@@ -1,8 +1,0 @@
-## Getting Started
-
-The best way to get started with eRegulations is via 
-[regulations-bootstrap](https://github.com/cfpb/regulations-bootstrap).
-This repository contains scripts that will setup a working copy of
-eRegulations either locally or in a virtual machine. 
-
-

--- a/_includes/technology/repo_sublist.html
+++ b/_includes/technology/repo_sublist.html
@@ -1,0 +1,10 @@
+{% comment %}Display a list of repos{% endcomment %}
+<ul>
+  {% for repo in include.repos %}
+    <li>
+      <a href="{{ repo.url }}">{{ repo.name }}</a>
+      <span>({{repo.short}})</span>
+      <p>{{ repo.long }}</p>
+    </li>
+  {% endfor %}
+</ul>

--- a/_includes/technology/repos.md
+++ b/_includes/technology/repos.md
@@ -1,62 +1,24 @@
-
 ## Repositories
 
-There are many individual repositories that make up eRegulations. These are divided below into the main body of eRegulations, tools to support eRegulations, and finally CFPB-specific modifications and data for eRegulations.
+There are many individual repositories that make up eRegulations; this is
+complicated by having two primary forks maintained by CFPB and 18F
+respectively. While these forks will ultimately be merged and maintenance
+shared between multiple agencies, those interested in using eRegs now should
+generally prefer the 18F repositories.
 
-{% if site.repos %}
+{% if site.general_repos %}
 <section id="main-repositories">
-  <h3 id="repositories">eRegulations</h3>
-  <ul class="repo-list group">
-    <li class="list-icon">
-      <img src="../assets/img/octocat.png" width="25px" alt="">
-    </li>
-    {% for repo in site.repos %}
-      <li>
-        <a href="{{ repo.url }}">
-          <h4>{{ repo.name }}</h4>
-          <p>{{ repo.description }}</p>
-        </a>
-      </li>
-    {% endfor %}
-  </ul>
+  <h3 id="repositories">General Purpose</h3>
+  {% include technology/repo_sublist.html repos=site.general_repos %}
 </section>
 {% endif %}
 
-{% if site.support_repos %}
-<section id="support-repositories">
-  <h3 id="repositories">Support</h3>
-  <ul class="repo-list group">
-    <li class="list-icon">
-      <img src="../assets/img/octocat.png" width="25px" alt="">
-    </li>
-    {% for repo in site.support_repos %}
-      <li>
-        <a href="{{ repo.url }}">
-          <h4>{{ repo.name }}</h4>
-          <p>{{ repo.description }}</p>
-        </a>
-      </li>
-    {% endfor %}
-  </ul>
+{% if site.agency_repos %}
+<section id="agency-repositories">
+  <h3 id="repositories">Agency-Specific Repos</h3>
+  {% for agency in site.agency_repos %}
+    <h4>{{agency.name}}</h4>
+    {% include technology/repo_sublist.html repos=agency.repos %}
+  {% endfor %}
 </section>
 {% endif %}
-
-{% if site.cfpb_repos %}
-<section id="cfpb-repositories">
-  <h3 id="repositories">CFPB-Specific</h3>
-  <ul class="repo-list group">
-    <li class="list-icon">
-      <img src="../assets/img/octocat.png" width="25px" alt="">
-    </li>
-    {% for repo in site.cfpb_repos %}
-      <li>
-        <a href="{{ repo.url }}">
-          <h4>{{ repo.name }}</h4>
-          <p>{{ repo.description }}</p>
-        </a>
-      </li>
-    {% endfor %}
-  </ul>
-</section>
-{% endif %}
-

--- a/_includes/technology/repos.md
+++ b/_includes/technology/repos.md
@@ -15,7 +15,7 @@ generally prefer the 18F repositories.
 
 {% if site.agency_repos %}
 <section id="agency-repositories">
-  <h3 id="repositories">Agency-Specific Repos</h3>
+  <h3 id="repositories">Agency-Centric</h3>
   {% for agency in site.agency_repos %}
     <h4>{{agency.name}}</h4>
     {% include technology/repo_sublist.html repos=agency.repos %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,11 +24,6 @@
     <div class="container">
       <header role="banner">
         <div class="wrap">
-          {% if site.logourl != null %}
-          <a href="http://www.consumerfinance.gov/" target="_blank">
-            <img class="logo" src="{{ site.logourl }}" alt="{{ site.logoalt }}">
-          </a>
-          {% endif %}
           <h1 class="site-title"><a class="title-link" href="{{ site.baseurl }}/">{{ site.name }}</a></h1>
         </div>
       </header>
@@ -45,7 +40,11 @@
 
       <footer role="contentinfo">
         <div class="wrap">
-          <p>This project is maintained by the <a href="{{ site.author.url }}">{{ site.author.name }}</a>.</p>
+          <p>This project is maintained by
+            the <a href="https://cfpb.github.io">CFPB</a>
+            and
+            <a href="https://18f.gsa.gov">18F</a>.
+          </p>
 
           <p>Hosted on <a href="http://pages.github.com/">GitHub Pages</a>.</p>
         </div><!--/.wrap -->

--- a/_pages/technology.md
+++ b/_pages/technology.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Technology
-subtemplates: [architecture, stack, repos, getting-started]
+subtemplates: [architecture, stack, repos]
 ---
 # Technology
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -34,30 +34,8 @@ Typography
 ==================================
 */
 
-@font-face {
-    font-family: "Avenir Next";
-    src: url("http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/f/e9167238-3b3f-4813-a04a-a384394eed42.eot");
-    src: url("http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/f/e9167238-3b3f-4813-a04a-a384394eed42.eot?#iefix") format("embedded-opentype"),
-         url("http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/f/1e9892c0-6927-4412-9874-1b82801ba47a.woff") format("woff"),
-         url("http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/f/46cf1067-688d-4aab-b0f7-bd942af6efd8.ttf") format("truetype"),
-         url("http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/f/52a192b1-bea5-4b48-879f-107f009b666f.svg#52a192b1-bea5-4b48-879f-107f009b666f") format("svg");
-    font-weight: 400;
-    font-style: normal;
-}
-
-@font-face {
-    font-family: "Avenir Next Demi";
-    src: url("http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/f/12d643f2-3899-49d5-a85b-ff430f5fad15.eot");
-    src: url("http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/f/12d643f2-3899-49d5-a85b-ff430f5fad15.eot?#iefix") format("embedded-opentype"),
-         url("http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/f/91b50bbb-9aa1-4d54-9159-ec6f19d14a7c.woff") format("woff"),
-         url("http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/f/a0f4c2f9-8a42-4786-ad00-fce42b57b148.ttf") format("truetype"),
-         url("http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/f/99affa9a-a5e9-4559-bd07-20cf0071852d.svg#99affa9a-a5e9-4559-bd07-20cf0071852d") format("svg");
-    font-weight: 700;
-    font-style: normal;
-}
-
 body {
-    font-family: "Avenir Next", Arial, sans-serif;
+    font-family: Arial, sans-serif;
     font-weight: 400;
     font-style: normal;
     line-height: 1.466666667;
@@ -68,13 +46,13 @@ h3,
 h4,
 h5,
 strong {
-    font-family: "Avenir Next Demi", "Avenir Next", Arial, sans-serif;
+    font-family: Arial, sans-serif;
     font-weight: 600;
 }
 
 .site-title {
     font-size: 1.625em;
-    font-family: "Avenir Next", Arial, sans-serif;
+    font-family: Arial, sans-serif;
     font-weight: normal;
     color: #919395;
     margin: 0;
@@ -359,7 +337,7 @@ li h4 {
 }
 
 .license {
-    font-family: "Avenir Next Demi", Arial, sans-serif;
+    font-family: Arial, sans-serif;
     font-weight: normal;
     font-style: normal;
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -34,8 +34,30 @@ Typography
 ==================================
 */
 
+@font-face {
+    font-family: "Avenir Next";
+    src: url("http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/f/e9167238-3b3f-4813-a04a-a384394eed42.eot");
+    src: url("http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/f/e9167238-3b3f-4813-a04a-a384394eed42.eot?#iefix") format("embedded-opentype"),
+         url("http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/f/1e9892c0-6927-4412-9874-1b82801ba47a.woff") format("woff"),
+         url("http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/f/46cf1067-688d-4aab-b0f7-bd942af6efd8.ttf") format("truetype"),
+         url("http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/f/52a192b1-bea5-4b48-879f-107f009b666f.svg#52a192b1-bea5-4b48-879f-107f009b666f") format("svg");
+    font-weight: 400;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: "Avenir Next Demi";
+    src: url("http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/f/12d643f2-3899-49d5-a85b-ff430f5fad15.eot");
+    src: url("http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/f/12d643f2-3899-49d5-a85b-ff430f5fad15.eot?#iefix") format("embedded-opentype"),
+         url("http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/f/91b50bbb-9aa1-4d54-9159-ec6f19d14a7c.woff") format("woff"),
+         url("http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/f/a0f4c2f9-8a42-4786-ad00-fce42b57b148.ttf") format("truetype"),
+         url("http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/f/99affa9a-a5e9-4559-bd07-20cf0071852d.svg#99affa9a-a5e9-4559-bd07-20cf0071852d") format("svg");
+    font-weight: 700;
+    font-style: normal;
+}
+
 body {
-    font-family: Arial, sans-serif;
+    font-family: "Avenir Next", Arial, sans-serif;
     font-weight: 400;
     font-style: normal;
     line-height: 1.466666667;
@@ -46,13 +68,13 @@ h3,
 h4,
 h5,
 strong {
-    font-family: Arial, sans-serif;
+    font-family: "Avenir Next Demi", "Avenir Next", Arial, sans-serif;
     font-weight: 600;
 }
 
 .site-title {
     font-size: 1.625em;
-    font-family: Arial, sans-serif;
+    font-family: "Avenir Next", Arial, sans-serif;
     font-weight: normal;
     color: #919395;
     margin: 0;
@@ -337,7 +359,7 @@ li h4 {
 }
 
 .license {
-    font-family: Arial, sans-serif;
+    font-family: "Avenir Next Demi", Arial, sans-serif;
     font-weight: normal;
     font-style: normal;
 }


### PR DESCRIPTION
Visible [here](http://cmc333333.github.io/eRegulations/)

This adds links to many, many more repos, including the 18F forks as "general purpose" for new agencies, CFPB's XML schema stuff, and an ATF-specific repo. These didn't fit well with the existing format (as they all have a longer explanation now), but I left in all of the styles + octocat in case we redesign this.

This also removes the CFPB logo, ~~Avenir Next (as it was never displayed)~~, and adds links to 18F
