### PR TITLE
Adding an "Introduction to regulations" page to help people understand eRegulations

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,6 +31,9 @@ navigation:
 - text: Technology
   url: 'technology/'
   internal: true
+- text: Introduction to regulations
+  url: 'introduction/'
+  internal: true
 
 
 general_repos:

--- a/_pages/introduction.md
+++ b/_pages/introduction.md
@@ -8,6 +8,8 @@ If you're interested in learning about eRegulations or contributing to its devel
 
 The [National Archives provides a brief overview of regulations](https://www.archives.gov/about/regulations/) which is helpful for quick context. There are detailed explanations of aspects of regulations on multiple websites, including [Regulations.gov](http://www.regulations.gov/#!home), [Reginfo.gov](http://www.reginfo.gov/public/), and various agency websites; here's the story all put together in the context of eRegulations (with links to those resources) to help you get started.
 
+We wrote this as an informal guide; if this information conflicts with explanations on linked websites such as Regulations.gov and Reginfo.gov, please consider them more authoritative.
+
 **Table of contents**
 
 * <a href="#what-are-regulations">What are regulations and where do they live?</a>

--- a/_pages/introduction.md
+++ b/_pages/introduction.md
@@ -1,0 +1,117 @@
+---
+layout: default
+title: Introduction to regulations
+---
+# Introduction to regulations
+
+If you're interested in learning about eRegulations or contributing to its development, it helps to have some background in what regulations are and how they fit into the legal landscape of the United States.
+
+The [National Archives has a summary](https://www.archives.gov/about/regulations/) and [Reginfo.gov provides an explanation of the regulatory process](http://www.reginfo.gov/public/jsp/Utilities/faq.jsp), and here's the story all put together to help you get started.
+
+**Table of contents**
+
+* <a href="#what-are-regulations">What are regulations and where do they live?</a>
+* <a href="#how-regulations-change">How regulations change (through “rules”)</a>
+* <a href="#structure">The structure of a regulation</a>
+* <a href="#definitions">Definitions of terms helpful for understanding eRegulations</a>
+
+## <a name="what-are-regulations"></a>What are regulations and where do they live?
+
+### Where regulations come from
+
+When Congress creates a law, it’s a big deal — a tremendous amount of effort goes into each new act of Congress. As a result, Congress usually describes the big picture of the law and gives authority to the relevant federal agencies to deal with the specifics. The agencies describe these details in regulations, which have the force and effect of law.
+
+How this gets written down: Congress writes “Acts” or “Statutes” which are cataloged in the [U.S. Code](https://www.gpo.gov/fdsys/browse/collectionUScode.action?collectionCode=USCODE) (USC). Each act or statute can give authority to specific federal regulatory agencies to write regulations. When the agencies write regulations, they are cataloged separately in the [Code of Federal Regulations](https://www.gpo.gov/fdsys/browse/collectionCfr.action?collectionCode=CFR) (CFR).
+
+### Who is responsible for regulations
+
+Federal agencies are responsible for maintaining and enforcing their own regulations. However, the Government Printing Office is the central repository for agency regulations. Generally, these two entities agree on what the “regulation” says, but if they ever differ (for example due to errors), the GPO “wins”.
+
+### Where regulations are published
+
+The Government Printing Office publishes an official printed paper Code of Federal Regulations and [official digital Code of Federal Regulations (on FDsys)](https://www.gpo.gov/fdsys/browse/collectionCfr.action?collectionCode=CFR) once a year.
+
+Throughout the year, GPO publishes changes to regulations through [e-CFR (Electronic Code of Federal Regulations)](http://www.ecfr.gov/), though this is not legally binding.
+
+Proposed changes and final changes effective some time in the future are published in the [Federal Register](https://www.federalregister.gov/) (the “Daily Journal of the United States Government”).
+
+## <a name="how-regulations-change"></a>How regulations change (through “rules”)
+
+For most changes (“rules”), an agency must propose the alterations and request the general public (including special interest groups, industry, etc.) provide feedback. The proposal includes a specific date by which all feedback must be received, though this can sometimes be modified. After the agency receives feedback, the agency must address each unique comment and draft a “final” rule which incorporates this feedback. The final rule is given an effective date, at which point the changes are applied to the regulation. This process is referred to as “notice and comment”. [A chart of the regulatory process.](http://www.reginfo.gov/public/reginfo/Regmap/index.jsp)
+
+There are a few different types of Federal Register Notices that can be part of a notice and comment process:
+
+### Advanced Notice of Proposed Rulemaking (ANPR)
+
+This doesn’t happen as often as the following notices. This usually happens before any change is made to a regulation. An ANPR is put out when an agency wants to check if an idea for future regulation change is something the public may want. It is meant to get early feedback from the public, and the issues in this notice may not move forward to the next notice depending on the public’s response.
+
+### Notice of Proposed Rulemaking (NPR) or Proposed Rule
+
+This is the initial draft of a change to a regulation. The notice starts with a “Preamble” which can contain the reasons for the regulation change, some section-by-section analysis, a cost analysis, and other general explanations. The Preamble is followed by the changes to the regulation. This notice only shows the actual changed parts of the regulation, not the new full text of the regulation.
+
+### Final Rule
+
+This is the final draft of a change to a regulation. This notice also starts with a Preamble and is followed by the changed parts of the regulation (not in context of the full text).
+
+### Interim Final Rule
+
+This is the same as a final rule except that it does not have to follow a proposed rule. This is uncommon. An example of this kind of rule: when CFPB was created, it reissued all of the regulations it was given authority over in full as interim final rules. There was no need for a notice and comment period.
+
+## <a name="structure"</a>The structure of a regulation
+
+Each regulation is part of the careful hierarchical structure of the Code of Federal Regulations. Here's a guide from the top down.
+
+### The Code of Federal Regulations contains “titles”
+
+The Code of Federal Regulations is broken into numeric “titles”, which each describe one subject area (such as “Domestic Security” or “Banks and Banking”). Agencies will most likely only cover one title. (1-50 is usually written in Roman numerals.)
+
+### Each title contains “parts” (“regulations”)
+
+CFR titles are broken into “parts”, which eRegulations consistently defines as the breaking point for a “regulation” (in other words: a “regulation” is a CFR part, for our purposes). These are numbered and further specify area of focus. A single agency will most likely cover multiple CFR parts. Technically, there can be a layer of categorization in between CFR titles and parts, but we ignore that for now. The format for this is `XX CFR XXX` or `title-number CFR part-number`.
+
+### Each part (regulation) contains components including “sections”
+
+A CFR part (or “regulation”) is further broken down into (often) Subparts, Subject Groups, Appendices, and Interpretations. Each of these components is optional, with Subparts and Appendices being lettered, and Interpretations technically being “Supplement I” within the Appendix.
+
+Subparts and Subject Groups are further broken into “sections”. Regulations without explicit subparts or subject groups will still have “sections.” These can be considered chapters in the book that is the regulation. The format for this is `XX CFR XXX.XsectionX`.
+
+### Each section contains paragraphs and subparagraphs
+
+Sections are then broken into paragraphs and subparagraphs, most often using these divisions: `(a)(1)(i)(A)(1)(i)(A)`, though this is not always consistent. We try to address every paragraph uniquely.
+
+That list of divisions is the “standard” format, but even if sections don't use that specific structure, they'll use some type of outline structure. There are technically rules that govern this structure, but since these regulations are written by humans, the type of outline structure can vary.
+
+## <a name="definitions"></a>Definitions of terms helpful for understanding eRegulations
+
+* **Act:** An act of Congress, i.e. the law. Acts generally provide authority to agencies to create and enforce regulations, giving the general outline of what needs to be enforced but allowing agencies to define the peculiarities.
+Agency: An arm of the federal government, which (for our purposes) defines and enforces regulations.
+
+* **Annual Edition:** Regulations are published in their entirety once a year in this edition. If there are multiple effective changes within a single year, individuals must pay attention and combine the relevant rules. Annual editions are not all published (as one might expect) once a year, across all agencies. Instead, the regulations are grouped into four chunks and released in January, April, July, and October.
+
+* **Appendix:** In addition to the main body of regulation text, regulations will often have one or more lettered “appendices”. These do not follow the paragraph-subparagraph conventions of the rest of the regulation, generally constructed in a free-form manner. They may contain safe-haven example documents, images, etc. which didn’t belong in the main regulation text.
+
+* **Code of Federal Regulations (CFR):** This is the collection of federal regulations, managed by the Government Printing Office (GPO). This is ground truth for regulation text; all agencies must place their regulations in the CFR.
+
+* **Definitions:** Most regulations will hinge on the meaning of certain terms, hence those terms are defined explicitly. These terms are also often “scoped” in the sense that the term only applies for a specific portion of the regulation. We make these terms clickable, to provide context when the terms are used throughout the regulation.
+
+* **Interpretation:** This is a component of a regulation which appears to be specific to CFPB (and perhaps other financial regulators). These regulations include a final appendix (“Supplement I”) which provides further analysis, explanation, and examples of the regulation and its appendices. We’ve displayed these in-line with the text they are describing.
+
+* **Keyterm:** This somewhat nebulous term refers to the highlighted first sentence or phrase in some paragraphs of the regulation. The idea is that this phrase categorizes the paragraph and all of its sub-paragraphs with some sort of meaning.
+
+* **Notice:** As we use the term, a notice is a proper superset of rules -- all rules (proposal or otherwise) are notices, but notices might include other messages which do not change the regulation. All notices have a “document number” which is their unique identifier.
+
+* **Notice and Comment:** This term refers to a period of time in the regulatory process when an agency proposes a new rule (i.e. change) and is seeking feedback from the public. It is a frequent pain point for agencies, which must receive and address all comments.
+
+* **Paragraph Marker:** Most regulation paragraphs are prefixed with a designator, e.g. “(a)” or “ix.”. This (along with the markers of containing paragraphs) allows individual paragraphs to be uniquely addressed.
+
+* **Regulation:** Think of this as a law with a specific scope. Regulations are generally much more detailed than Acts. These are the core type of content we are trying to display.
+
+* **Rule:** This is a change to a regulation; the term can sometimes refer generically to regulations (e.g. “you must follow these rules and regulations”), but we avoid that usage within eRegulations. Rules are printed in the Federal Register and have two primary categorizations:
+
+	* **Proposed Rule:** These describe changes an agency is considering. The idea is to provide the changes (and some explanation) and ask the public to comment on these proposed changes. Generally, there is a period of time before the commenting window closes
+
+	* **Final Rule:** After an agency has made its proposal and received feedback, it issues a “final” change to the regulation. These will generally have an “effective date”, when the changes are to go into effect
+
+* **Section-by-section Analyses (SxS):** When rules describe changes to a regulation, they often contain an analysis of changes to specific sections, paragraphs, and the like. These analyses are captured and presented by eRegulations as they may be useful when trying to understand the context of a particular paragraph. These may be a CFPB-specific idiom, but it is currently unclear.
+
+* **Version:** This is a term that lawyers will not use, but which makes discussing eRegulations much easier. As we track how the regulation changes over time, we generate different versions of it. These versions are given unique identifiers (usually corresponding to the document number of the final rule which caused the change) and associated with specific effective dates.

--- a/_pages/introduction.md
+++ b/_pages/introduction.md
@@ -6,20 +6,20 @@ title: Introduction to regulations
 
 If you're interested in learning about eRegulations or contributing to its development, it helps to have some background in what regulations are and how they fit into the legal landscape of the United States.
 
-The [National Archives has a summary](https://www.archives.gov/about/regulations/) and [Reginfo.gov provides an explanation of the regulatory process](http://www.reginfo.gov/public/jsp/Utilities/faq.jsp), and here's the story all put together to help you get started.
+The [National Archives provides a brief overview of regulations](https://www.archives.gov/about/regulations/) which is helpful for quick context. There are detailed explanations of aspects of regulations on multiple websites, including [Regulations.gov](http://www.regulations.gov/#!home), [Reginfo.gov](http://www.reginfo.gov/public/), and various agency websites; here's the story all put together in the context of eRegulations (with links to those resources) to help you get started.
 
 **Table of contents**
 
 * <a href="#what-are-regulations">What are regulations and where do they live?</a>
 * <a href="#how-regulations-change">How regulations change (through “rules”)</a>
 * <a href="#structure">The structure of a regulation</a>
-* <a href="#definitions">Definitions of terms as used in eRegulations</a>
+* <a href="#definitions">Definitions of terms used in eRegulations</a>
 
 ## <a name="what-are-regulations"></a>What are regulations and where do they live?
 
 ### Where regulations come from
 
-When Congress creates a law, it’s a big deal — a tremendous amount of effort goes into each new act of Congress. As a result, Congress usually describes the big picture of the law and gives authority to the relevant federal agencies to deal with the specifics. The agencies describe these details in regulations, which have the force and effect of law.
+When Congress creates a law, it’s a big deal — a tremendous amount of effort goes into each new act of Congress. As a result, Congress usually describes the big picture of the law and gives authority to the relevant federal agencies to deal with the specifics. The agencies describe these details in regulations, which have the force and effect of law. ([The first two answers in this Reginfo.gov FAQ provide details about this process.](http://www.reginfo.gov/public/jsp/Utilities/faq.jsp))
 
 How this gets written down: Congress writes “Acts” or “Statutes” which are cataloged in the [U.S. Code](https://www.gpo.gov/fdsys/browse/collectionUScode.action?collectionCode=USCODE) (USC). Each act or statute can give authority to specific federal regulatory agencies to write regulations. When the agencies write regulations, they are cataloged separately in the [Code of Federal Regulations](https://www.gpo.gov/fdsys/browse/collectionCfr.action?collectionCode=CFR) (CFR).
 
@@ -37,7 +37,9 @@ Proposed changes and final changes effective some time in the future are publish
 
 ## <a name="how-regulations-change"></a>How regulations change (through “rules”)
 
-For most changes (“rules”), an agency must propose the alterations and request the general public (including special interest groups, industry, etc.) provide feedback. The proposal includes a specific date by which all feedback must be received, though this can sometimes be modified. After the agency receives feedback, the agency must address each unique comment; they may draft a “final” rule which incorporates this feedback, make a different proposal, or decide to not follow up on the proposal. If they produce a final rule, they give it an effective date, at which point the changes are applied to the regulation. This process is referred to as “notice and comment”. [A chart of the regulatory process.](http://www.reginfo.gov/public/reginfo/Regmap/index.jsp)
+For most changes (“rules”), an agency must propose the alterations and request the general public (including special interest groups, industry, etc.) provide feedback. The proposal includes a specific date by which all feedback must be received, though this can sometimes be modified. After the agency receives feedback, the agency must review each unique comment; they may draft a “final” rule which incorporates this feedback, make a different proposal, or withdraw the proposal. If they produce a final rule, they give it an effective date, at which point the changes are applied to the regulation. This process is referred to as “notice and comment”.
+
+Regulations.gov provides [a summary of the steps of the regulatory (rulemaking) process](http://www.regulations.gov/#!home;tab=learn), the Department of Transportation provides [a more in-depth overview of the process](https://www.transportation.gov/regulations/rulemaking-process), and Reginfo.gov provides [a detailed chart of the process (the "Reg Map")](http://www.reginfo.gov/public/reginfo/Regmap/index.jsp).
 
 There are a few different types of Federal Register Notices that can be part of a notice and comment process:
 
@@ -59,7 +61,7 @@ This is the same as a final rule except that it does not have to follow a propos
 
 ## <a name="structure"></a>The structure of a regulation
 
-Each regulation is part of the careful hierarchical structure of the Code of Federal Regulations, and eRegulations reflects this structure. Here's a guide from the top down.
+Each regulation is part of the careful hierarchical structure of the [Code of Federal Regulations](https://www.gpo.gov/fdsys/browse/collectionCfr.action?collectionCode=CFR), and eRegulations reflects this structure. Here's a guide from the top down.
 
 ### The Code of Federal Regulations contains “titles”
 
@@ -81,9 +83,9 @@ Sections are then broken into paragraphs and subparagraphs, most often using the
 
 That list of divisions is the “standard” format, but even if sections don't use that specific structure, they'll use some type of outline structure. There are technically rules that govern this structure, but since these regulations are written by humans, the type of outline structure can vary.
 
-## <a name="definitions"></a>Definitions of terms as used in eRegulations
+## <a name="definitions"></a>Definitions of terms used in eRegulations
 
-While reading about or using eRegulations, you'll run into a number of terms that have specific meanings when dealing with regulations (and some that are specific to eRegulations). Here's what they mean.
+While reading about or using eRegulations, you'll run into a number of terms that have specific meanings when dealing with regulations, along with some terms that are specific to eRegulations. Here's what they mean in the context of eRegulations. (To learn more about regulatory terms, [Regulations.gov offers a glossary of terms used on that site](http://www.regulations.gov/#!glossary).)
 
 * **Act:** An act of Congress, i.e. the law. Acts generally provide authority to agencies to create and enforce regulations, giving the general outline of what needs to be enforced but allowing agencies to define the peculiarities.
 
@@ -117,4 +119,4 @@ While reading about or using eRegulations, you'll run into a number of terms tha
 
 * **Section-by-section Analyses (SxS):** When rules describe changes to a regulation, they often contain an analysis of changes to specific sections, paragraphs, and the like. These analyses are captured and presented by eRegulations as they may be useful when trying to understand the context of a particular paragraph. These may be a CFPB-specific idiom, but it is currently unclear.
 
-* **Version:** As we track how the regulation changes over time, we generate different versions of it. These versions are given unique identifiers (usually corresponding to the document number of the final rule which caused the change) and associated with specific effective dates.
+* **Version:** eRegulations can present older and newer versions of a regulation for your comparison, to help you track how a regulation changes over time. These versions are given unique identifiers (usually corresponding to the document number of the final rule which caused the change) and associated with specific effective dates.

--- a/_pages/introduction.md
+++ b/_pages/introduction.md
@@ -13,7 +13,7 @@ The [National Archives has a summary](https://www.archives.gov/about/regulations
 * <a href="#what-are-regulations">What are regulations and where do they live?</a>
 * <a href="#how-regulations-change">How regulations change (through “rules”)</a>
 * <a href="#structure">The structure of a regulation</a>
-* <a href="#definitions">Definitions of terms helpful for understanding eRegulations</a>
+* <a href="#definitions">Definitions of terms as used in eRegulations</a>
 
 ## <a name="what-are-regulations"></a>What are regulations and where do they live?
 
@@ -37,7 +37,7 @@ Proposed changes and final changes effective some time in the future are publish
 
 ## <a name="how-regulations-change"></a>How regulations change (through “rules”)
 
-For most changes (“rules”), an agency must propose the alterations and request the general public (including special interest groups, industry, etc.) provide feedback. The proposal includes a specific date by which all feedback must be received, though this can sometimes be modified. After the agency receives feedback, the agency must address each unique comment and draft a “final” rule which incorporates this feedback. The final rule is given an effective date, at which point the changes are applied to the regulation. This process is referred to as “notice and comment”. [A chart of the regulatory process.](http://www.reginfo.gov/public/reginfo/Regmap/index.jsp)
+For most changes (“rules”), an agency must propose the alterations and request the general public (including special interest groups, industry, etc.) provide feedback. The proposal includes a specific date by which all feedback must be received, though this can sometimes be modified. After the agency receives feedback, the agency must address each unique comment; they may draft a “final” rule which incorporates this feedback, make a different proposal, or decide to not follow up on the proposal. If they produce a final rule, they give it an effective date, at which point the changes are applied to the regulation. This process is referred to as “notice and comment”. [A chart of the regulatory process.](http://www.reginfo.gov/public/reginfo/Regmap/index.jsp)
 
 There are a few different types of Federal Register Notices that can be part of a notice and comment process:
 
@@ -57,9 +57,9 @@ This is the final draft of a change to a regulation. This notice also starts wit
 
 This is the same as a final rule except that it does not have to follow a proposed rule. This is uncommon. An example of this kind of rule: when CFPB was created, it reissued all of the regulations it was given authority over in full as interim final rules. There was no need for a notice and comment period.
 
-## <a name="structure"</a>The structure of a regulation
+## <a name="structure"></a>The structure of a regulation
 
-Each regulation is part of the careful hierarchical structure of the Code of Federal Regulations. Here's a guide from the top down.
+Each regulation is part of the careful hierarchical structure of the Code of Federal Regulations, and eRegulations reflects this structure. Here's a guide from the top down.
 
 ### The Code of Federal Regulations contains “titles”
 
@@ -81,10 +81,13 @@ Sections are then broken into paragraphs and subparagraphs, most often using the
 
 That list of divisions is the “standard” format, but even if sections don't use that specific structure, they'll use some type of outline structure. There are technically rules that govern this structure, but since these regulations are written by humans, the type of outline structure can vary.
 
-## <a name="definitions"></a>Definitions of terms helpful for understanding eRegulations
+## <a name="definitions"></a>Definitions of terms as used in eRegulations
+
+While reading about or using eRegulations, you'll run into a number of terms that have specific meanings when dealing with regulations (and some that are specific to eRegulations). Here's what they mean.
 
 * **Act:** An act of Congress, i.e. the law. Acts generally provide authority to agencies to create and enforce regulations, giving the general outline of what needs to be enforced but allowing agencies to define the peculiarities.
-Agency: An arm of the federal government, which (for our purposes) defines and enforces regulations.
+
+* **Agency:** An arm of the federal government, which (for our purposes) defines and enforces regulations.
 
 * **Annual Edition:** Regulations are published in their entirety once a year in this edition. If there are multiple effective changes within a single year, individuals must pay attention and combine the relevant rules. Annual editions are not all published (as one might expect) once a year, across all agencies. Instead, the regulations are grouped into four chunks and released in January, April, July, and October.
 
@@ -94,11 +97,11 @@ Agency: An arm of the federal government, which (for our purposes) defines and e
 
 * **Definitions:** Most regulations will hinge on the meaning of certain terms, hence those terms are defined explicitly. These terms are also often “scoped” in the sense that the term only applies for a specific portion of the regulation. We make these terms clickable, to provide context when the terms are used throughout the regulation.
 
-* **Interpretation:** This is a component of a regulation which appears to be specific to CFPB (and perhaps other financial regulators). These regulations include a final appendix (“Supplement I”) which provides further analysis, explanation, and examples of the regulation and its appendices. We’ve displayed these in-line with the text they are describing.
+* **Interpretation:** Agencies may provide various kinds of interpretive materials along with their regulations, such as rulings or advisory opinions. An "official interpretation" is a component of a regulation which appears to be specific to CFPB (and perhaps other financial regulators). Those regulations include a final appendix (“Supplement I”) which provides further analysis, explanation, and examples of the regulation and its appendices. We display these in-line with the text they are describing.
 
 * **Keyterm:** This somewhat nebulous term refers to the highlighted first sentence or phrase in some paragraphs of the regulation. The idea is that this phrase categorizes the paragraph and all of its sub-paragraphs with some sort of meaning.
 
-* **Notice:** As we use the term, a notice is a proper superset of rules -- all rules (proposal or otherwise) are notices, but notices might include other messages which do not change the regulation. All notices have a “document number” which is their unique identifier.
+* **Notice:** As we use the term, a notice is a proper superset of rules — all rules (proposal or otherwise) are notices, but notices might include other messages which do not change the regulation. All notices have a “document number” which is their unique identifier.
 
 * **Notice and Comment:** This term refers to a period of time in the regulatory process when an agency proposes a new rule (i.e. change) and is seeking feedback from the public. It is a frequent pain point for agencies, which must receive and address all comments.
 
@@ -114,4 +117,4 @@ Agency: An arm of the federal government, which (for our purposes) defines and e
 
 * **Section-by-section Analyses (SxS):** When rules describe changes to a regulation, they often contain an analysis of changes to specific sections, paragraphs, and the like. These analyses are captured and presented by eRegulations as they may be useful when trying to understand the context of a particular paragraph. These may be a CFPB-specific idiom, but it is currently unclear.
 
-* **Version:** This is a term that lawyers will not use, but which makes discussing eRegulations much easier. As we track how the regulation changes over time, we generate different versions of it. These versions are given unique identifiers (usually corresponding to the document number of the final rule which caused the change) and associated with specific effective dates.
+* **Version:** As we track how the regulation changes over time, we generate different versions of it. These versions are given unique identifiers (usually corresponding to the document number of the final rule which caused the change) and associated with specific effective dates.

--- a/_pages/introduction.md
+++ b/_pages/introduction.md
@@ -85,7 +85,7 @@ That list of divisions is the “standard” format, but even if sections don't 
 
 ## <a name="definitions"></a>Definitions of terms used in eRegulations
 
-While reading about or using eRegulations, you'll run into a number of terms that have specific meanings when dealing with regulations, along with some terms that are specific to eRegulations. Here's what they mean in the context of eRegulations. (To learn more about regulatory terms, [Regulations.gov offers a glossary of terms used on that site](http://www.regulations.gov/#!glossary).)
+While reading about or using eRegulations, you'll run into a number of terms that have specific meanings when dealing with regulations, along with some terms that are specific to eRegulations. Here's what they mean in the context of eRegulations. (To learn more about terms related to regulations, [Regulations.gov offers a glossary of terms used on that site](http://www.regulations.gov/#!glossary).)
 
 * **Act:** An act of Congress, i.e. the law. Acts generally provide authority to agencies to create and enforce regulations, giving the general outline of what needs to be enforced but allowing agencies to define the peculiarities.
 

--- a/_pages/introduction.md
+++ b/_pages/introduction.md
@@ -31,11 +31,11 @@ Federal agencies are responsible for maintaining and enforcing their own regulat
 
 ### Where regulations are published
 
-The Government Printing Office publishes an official printed paper Code of Federal Regulations and [official digital Code of Federal Regulations (on FDsys)](https://www.gpo.gov/fdsys/browse/collectionCfr.action?collectionCode=CFR) once a year.
+Agencies publish proposed changes and final changes (effective some time in the future) in the [Federal Register](https://www.federalregister.gov/), which is the “Daily Journal of the United States Government”.
 
-Throughout the year, GPO publishes changes to regulations through [e-CFR (Electronic Code of Federal Regulations)](http://www.ecfr.gov/), though this is not legally binding.
+Throughout the year, Government Printing Office updates the unofficial [e-CFR (Electronic Code of Federal Regulations)](http://www.ecfr.gov/) almost every day to integrate each of those final changes when they take effect, so that you can easily read up-to-date regulations in a central place. The e-CFR is not an official legal edition of these regulations; it is not legally binding.
 
-Proposed changes and final changes effective some time in the future are published in the [Federal Register](https://www.federalregister.gov/) (the “Daily Journal of the United States Government”).
+Each regulation gets an official update in the Code of Federal Regulations once a year. The Government Printing Office puts together all of the final changes and publishes them in the official Code of Federal Regulations, in both printed paper books and the [official digital Code of Federal Regulations (on FDsys)](https://www.gpo.gov/fdsys/browse/collectionCfr.action?collectionCode=CFR). (Although instead of publishing the entire updated Code of Regulations on one big day every year, the GPO splits the Code of Federal Regulations into four chunks and updates one of them each quarter of the year.)
 
 ## <a name="how-regulations-change"></a>How regulations change (through “rules”)
 
@@ -45,17 +45,17 @@ Regulations.gov provides [a summary of the steps of the regulatory (rulemaking) 
 
 There are a few different types of Federal Register Notices that can be part of a notice and comment process:
 
-### Advanced Notice of Proposed Rulemaking (ANPR)
+### Advance Notice of Proposed Rulemaking (ANPR)
 
-This doesn’t happen as often as the following notices. This usually happens before any change is made to a regulation. An ANPR is put out when an agency wants to check if an idea for future regulation change is something the public may want. It is meant to get early feedback from the public, and the issues in this notice may not move forward to the next notice depending on the public’s response.
+This doesn’t happen as often as the following notices. An ANPR is put out when an agency wants to check if an idea for future regulation change is something the public may want. It is meant to get early feedback from the public, and the issues in this notice may not move forward to the next notice depending on the public’s response.
 
 ### Notice of Proposed Rulemaking (NPR) or Proposed Rule
 
-This is the initial draft of a change to a regulation. The notice starts with a “Preamble” which can contain the reasons for the regulation change, some section-by-section analysis, a cost analysis, and other general explanations. The Preamble is followed by the changes to the regulation. This notice only shows the actual changed parts of the regulation, not the new full text of the regulation.
+This is the initial draft of a change to a regulation. The notice starts with a “Preamble” which can contain the reasons for the regulation change, some section-by-section analysis, a cost analysis, and other general explanations. The Preamble is followed by the proposed changes to the regulation. The notice does not contain the complete text of the new regulation, so readers need to find and compare the previous version of the regulation to make sense of the changes.
 
 ### Final Rule
 
-This is the final draft of a change to a regulation. This notice also starts with a Preamble and is followed by the changed parts of the regulation (not in context of the full text).
+This is the final draft of a change to a regulation. This notice also starts with a Preamble, which addresses the comments received during the notice and comment period. This Preamble is followed by the changed parts of the regulation (not in context of the full text).
 
 ### Interim Final Rule
 
@@ -67,7 +67,7 @@ Each regulation is part of the careful hierarchical structure of the [Code of Fe
 
 ### The Code of Federal Regulations contains “titles”
 
-The Code of Federal Regulations is broken into numeric “titles”, which each describe one subject area (such as “Domestic Security” or “Banks and Banking”). Agencies will most likely only cover one title. (1-50 is usually written in Roman numerals.)
+The Code of Federal Regulations is broken into 50 numbered “titles”, which each describe one broad subject area. For example, Title 6 is “Domestic Security” and Title 12 is “Banks and Banking”. Each agency usually only covers one title. The title numbers are often written with Roman numerals (as in "Title XXVII").
 
 ### Each title contains “parts” (“regulations”)
 
@@ -77,11 +77,11 @@ CFR titles are broken into “parts”, which eRegulations consistently defines 
 
 A CFR part (or “regulation”) is further broken down into (often) Subparts, Subject Groups, Appendices, and Interpretations. Each of these components is optional, with Subparts and Appendices being lettered, and Interpretations technically being “Supplement I” within the Appendix.
 
-Subparts and Subject Groups are further broken into “sections”. Regulations without explicit subparts or subject groups will still have “sections.” These can be considered chapters in the book that is the regulation. The format for this is `XX CFR XXX.XsectionX`.
+Subparts and Subject Groups are further broken into “sections”. Regulations without explicit subparts or subject groups will still have “sections.” The format for this is `XX CFR XXX.XsectionX`.
 
-### Each section contains paragraphs and subparagraphs
+### Many sections contain paragraphs and subparagraphs
 
-Sections are then broken into paragraphs and subparagraphs, most often using these divisions: `(a)(1)(i)(A)(1)(i)(A)`, though this is not always consistent. We try to address every paragraph uniquely.
+Sections are often broken into paragraphs and subparagraphs, most often using these divisions: `(a)(1)(i)(A)(1)(i)(A)`, though this is not always consistent. We try to address every paragraph uniquely.
 
 That list of divisions is the “standard” format, but even if sections don't use that specific structure, they'll use some type of outline structure. There are technically rules that govern this structure, but since these regulations are written by humans, the type of outline structure can vary.
 


### PR DESCRIPTION
To help people understand eRegulations (especially potential contributors and users), this adds a page with background information about regulations, customized to the needs of people interested in eRegulations. It explains what regulations are, how they change, their structure, and definitions of terms used in eRegulations (and in discussions among contributors).

Original issue filed over here: https://github.com/18F/atf-eregs/issues/195

This could still use more review for accuracy, and suggestions/comments are welcome!
