### PR TITLE
Rearrange site to have a landing page that links to sub-pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,13 +22,13 @@ baseurl: '/eRegulations'
 # Navigation
 # List links that should appear in the site sidebar here
 navigation:
-- text: Live Instances
-  url: '#live-instances'
+- text: Overview and live instances
+  url: ''
   internal: true
 - text: Features
-  url: '#features'
+  url: 'features/'
   internal: true
-- text: Technology
+- text: Code and documentation
   url: 'technology/'
   internal: true
 - text: Introduction to regulations
@@ -132,7 +132,7 @@ agency_repos:
 # Style Variables
 brand_color: "#2cb34a"
 
-# eRegs instances in the while
+# eRegs instances in the wild
 instances:
 - url: http://www.consumerfinance.gov/eregulations/
   title: 12

--- a/_includes/index.md
+++ b/_includes/index.md
@@ -14,4 +14,4 @@ We invite contributions to any part of the application, from people inside and o
 
 ## Introduction to regulations
 
-If you’re interested in learning about eRegulations or contributing to its development, it helps to have some background in what regulations are and how they fit into the legal landscape of the United States. [We wrote an informal guide for you.](introduction/)
+If you’re interested in learning about eRegulations or contributing to its development, it helps to have some background in what regulations are and how they fit into the legal landscape of the United States. [We wrote an informal guide.](introduction/)

--- a/_includes/index.md
+++ b/_includes/index.md
@@ -1,41 +1,19 @@
 ## Features
 
-eRegulations includes an illustrated user guide that explains its features — see this live on [the CFPB eRegulations "About" page](http://www.consumerfinance.gov/eregulations/about) and [the ATF eRegulations "About" page](https://atf-eregs.apps.cloud.gov/about).
+See the illustrated guide to eRegulations features on [its CFPB "About" page](http://www.consumerfinance.gov/eregulations/about) and [its ATF "About" page](https://atf-eregs.apps.cloud.gov/about).
 
-In more detail, some of the main features of the tool are:
+[More detail about the main features.](features/)
 
-- #### NAVIGABILITY.
-While regulations are traditionally represented as monolithic blocks of text, they contain a great deal of embedded structure. eRegulations teases out that structure and uses it to present the text in a clean, readable form.
+## Code and documentation
 
-- #### INLINE INTERPRETATIONS.
-Many regulation paragraphs have official interpretations that have traditionally been displayed at the end of the regulation, forcing readers to swap back and forth between the regulation content and interpretation at the end. eRegulations parses the interpretations for each paragraph, and displays them right under the paragraph/section being interpreted.
+[Overview of eRegulations technology and repositories.](technology/)
 
-- #### DEFINITIONS.
-We highlight words that have been defined in the regulation, and the user can click on the word and see it's definition without scrolling to the part of the regulation that defines that word.
+### Open source and contributing
 
-- #### INTERNAL CITATIONS.
-The parser parses out all internal citations in the regulation, and we display them as clickable links allowing easy navigation within a regulation.
-
-- #### SEARCH.
-We provide the ability to search for phrases across various versions of a regulation.
-
-- #### ALTERNATE VERSIONS OF THE REGULATIONS.
-Regulations are evolving documents and are often displayed as changes to the base text. We present whole versions of regulations for each set of changes (We combine Final Rules that have a common effective date into a version).
-
-- #### COMPARING VERSIONS.
-We show the difference between whole versions of regulations in a "redline" or word-by-word comparison view. All changes are expressed as additions (shown in green) or deletions (struck-through, lighter gray). This view clearly shows how a regulation changes.
-
-- #### RETRIEVE BY EFFECTIVE DATE.
-A user can also enter in a date, and retrieve the version of the regulation effective at that point in time.
-
-- #### SECTION-BY-SECTION ANALYSIS.
-The notices that compose a version of the regulation contain relevant analyses of the altered sections. We automatically pull that information out and make it accessible while reading the regulation text.
-
-- #### RESPONSIVE DESIGN.
-The application design is responsive, adjusting to the device and screen size of the user.
-
-## Open Source and Contributing
-
-We invite contributions to any part of the application. The project is in the public domain, and all contributions to it will be released as such. By submitting a pull request, you are agreeing to waive all rights to your contribution under the terms of the [CC0 Public Domain Dedication](http://creativecommons.org/publicdomain/zero/1.0/).
+We invite contributions to any part of the application, from people inside and outside government. The project is in the public domain, and all contributions to it will be released as such. By submitting a pull request, you are agreeing to waive all rights to your contribution under the terms of the [CC0 Public Domain Dedication](http://creativecommons.org/publicdomain/zero/1.0/).
 
 If you contribute the open source work of others, please mark it clearly in your pull request.
+
+## Introduction to regulations
+
+If you’re interested in learning about eRegulations or contributing to its development, it helps to have some background in what regulations are and how they fit into the legal landscape of the United States. [We wrote an informal guide for you.](introduction/)

--- a/_includes/index.md
+++ b/_includes/index.md
@@ -10,9 +10,7 @@ See the illustrated guide to eRegulations features on [its CFPB "About" page](ht
 
 ### Open source and contributing
 
-We invite contributions to any part of the application, from people inside and outside government. The project is in the public domain, and all contributions to it will be released as such. By submitting a pull request, you are agreeing to waive all rights to your contribution under the terms of the [CC0 Public Domain Dedication](http://creativecommons.org/publicdomain/zero/1.0/).
-
-If you contribute the open source work of others, please mark it clearly in your pull request.
+We invite contributions to any part of the application, from people inside and outside government. The project is in the public domain, and all contributions to it will be released as such. By submitting a pull request, you are agreeing to waive all rights to your contribution under the terms of the [CC0 Public Domain Dedication](http://creativecommons.org/publicdomain/zero/1.0/). If you contribute the open source work of others, please mark it clearly in your pull request.
 
 ## Introduction to regulations
 

--- a/_includes/instances.md
+++ b/_includes/instances.md
@@ -1,7 +1,7 @@
-## Live Instances
+## Live instances
 
 The application is typically hosted by individual federal agencies, with
-features, branding, etc. unique to their users and needs. Current instances of
+features and branding unique to their users and needs. Current instances of
 eRegs include:
 
 <section>

--- a/_includes/intro.md
+++ b/_includes/intro.md
@@ -1,5 +1,3 @@
 eRegulations is a web-based application that makes regulations easier to find,
-read and understand. It is a work in progress by the [Consumer Financial Protection Bureau](http://consumerfinance.gov/)
-and [18F](https://18f.gsa.gov/). It is a public domain work of the United
-States Government.
+read and understand. It is a work in progress by the [Consumer Financial Protection Bureau](http://consumerfinance.gov/) and [18F](https://18f.gsa.gov/). It is a public domain and [open source](#open-source-and-contributing) work of the United States government.
 

--- a/_includes/technology/architecture.md
+++ b/_includes/technology/architecture.md
@@ -1,7 +1,5 @@
-## Architecture
+### Architecture
 
-There are three primary parts to the eRegulations application: a parser that converts regulation text into data (regulations-parser), an API that hosts this data (regulations-core), and a webapp which uses the data from the API to construct beautiful and usable regulations (regulations-site).
+There are three primary parts to the eRegulations application: a parser that converts regulation text into data (**regulations-parser**), an API that hosts this data (**regulations-core**), and a webapp which uses the data from the API to construct beautiful and usable regulations (**regulations-site**).
 
-One would typically run the parser against a regulation once (for each version) to populate the API with all the necessary data. regulations-site would then use regulations-core to as necessary to display regulations.
-
-
+You typically run the parser against a regulation once (for each version) to populate the API with all the necessary data. **regulations-site** would then use **regulations-core** as necessary to display regulations.

--- a/_includes/technology/architecture.md
+++ b/_includes/technology/architecture.md
@@ -2,4 +2,4 @@
 
 There are three primary parts to the eRegulations application: a parser that converts regulation text into data (**regulations-parser**), an API that hosts this data (**regulations-core**), and a webapp which uses the data from the API to construct beautiful and usable regulations (**regulations-site**).
 
-You typically run the parser against a regulation once (for each version) to populate the API with all the necessary data. **regulations-site** would then use **regulations-core** as necessary to display regulations.
+One would typically run the parser against a regulation once (for each version) to populate the API with all the necessary data. **regulations-site** would then use **regulations-core** as necessary to display regulations.

--- a/_includes/technology/repo_sublist.html
+++ b/_includes/technology/repo_sublist.html
@@ -2,7 +2,7 @@
 <ul>
   {% for repo in include.repos %}
     <li>
-      <a href="{{ repo.url }}">{{ repo.name }}</a>
+      <strong><a href="{{ repo.url }}">{{ repo.name }}</a></strong>
       <span>({{repo.short}})</span>
       <p>{{ repo.long }}</p>
     </li>

--- a/_includes/technology/repos.md
+++ b/_includes/technology/repos.md
@@ -2,7 +2,7 @@
 
 There are many individual repositories that make up eRegulations. The project is divided into several components, and currently CFPB and 18F maintain two separate forks of **regulations-parser**, **regulations-core**, and **regulations-site**. 18F and CFPB plan to eventually merge these forks into shared components with maintenance shared between multiple agencies. For now, in most cases people interested in using eRegulations should use the 18F repositories (listed under "General Purpose").
 
-*Tip: If you'd simply like to get a local copy of eRegulations set up to try it out, try starting with [CFPB **regulations-bootstrap**](https://github.com/cfpb/regulations-bootstrap) or [ATF **atf-eregs**](https://github.com/18F/atf-eregs), which are both also listed below.*
+*Tip: If you'd simply like to get a copy of eRegulations set up to try it out, try starting with [CFPB **regulations-bootstrap**](https://github.com/cfpb/regulations-bootstrap) or [ATF **atf-eregs**](https://github.com/18F/atf-eregs), which are both also listed below.*
 
 {% if site.general_repos %}
 <section id="main-repositories">

--- a/_includes/technology/repos.md
+++ b/_includes/technology/repos.md
@@ -1,10 +1,6 @@
 ## Repositories
 
-There are many individual repositories that make up eRegulations; this is
-complicated by having two primary forks maintained by CFPB and 18F
-respectively. While these forks will ultimately be merged and maintenance
-shared between multiple agencies, those interested in using eRegs now should
-generally prefer the 18F repositories.
+There are many repositories that make up eRegulations: the project is split into several components, and currently CFPB and 18F maintain two separate forks of **regulations-parser**, **regulations-core**, and **regulations-site**. 18F and CFPB plan to eventually merge these forks into shared components with maintenance shared between multiple agencies. For now, in most cases people interested in using eRegulations should use the 18F repositories (listed under "General Purpose").
 
 {% if site.general_repos %}
 <section id="main-repositories">

--- a/_includes/technology/repos.md
+++ b/_includes/technology/repos.md
@@ -2,7 +2,7 @@
 
 There are many individual repositories that make up eRegulations. The project is divided into several components, and currently CFPB and 18F maintain two separate forks of **regulations-parser**, **regulations-core**, and **regulations-site**. 18F and CFPB plan to eventually merge these forks into shared components with maintenance shared between multiple agencies. For now, in most cases people interested in using eRegulations should use the 18F repositories (listed under "General Purpose").
 
-*Tip: If you'd simply like to get a copy of eRegulations set up to try it out, try starting with [CFPB **regulations-bootstrap**](https://github.com/cfpb/regulations-bootstrap) or [ATF **atf-eregs**](https://github.com/18F/atf-eregs), which are both also listed below.*
+*Tip: If you'd like to get an example eRegulations site set up to try it out, check out [CFPB **regulations-bootstrap**](https://github.com/cfpb/regulations-bootstrap) to install a CFPB-centric version.*
 
 {% if site.general_repos %}
 <section id="main-repositories">

--- a/_includes/technology/repos.md
+++ b/_includes/technology/repos.md
@@ -1,17 +1,19 @@
 ## Repositories
 
-There are many repositories that make up eRegulations: the project is split into several components, and currently CFPB and 18F maintain two separate forks of **regulations-parser**, **regulations-core**, and **regulations-site**. 18F and CFPB plan to eventually merge these forks into shared components with maintenance shared between multiple agencies. For now, in most cases people interested in using eRegulations should use the 18F repositories (listed under "General Purpose").
+There are many individual repositories that make up eRegulations. The project is divided into several components, and currently CFPB and 18F maintain two separate forks of **regulations-parser**, **regulations-core**, and **regulations-site**. 18F and CFPB plan to eventually merge these forks into shared components with maintenance shared between multiple agencies. For now, in most cases people interested in using eRegulations should use the 18F repositories (listed under "General Purpose").
+
+*Tip: If you'd simply like to get a local copy of eRegulations set up to try it out, try starting with [CFPB **regulations-bootstrap**](https://github.com/cfpb/regulations-bootstrap) or [ATF **atf-eregs**](https://github.com/18F/atf-eregs), which are both also listed below.*
 
 {% if site.general_repos %}
 <section id="main-repositories">
-  <h3 id="repositories">General Purpose</h3>
+  <h3 id="repositories">The main body of eRegulations (not agency-specific)</h3>
   {% include technology/repo_sublist.html repos=site.general_repos %}
 </section>
 {% endif %}
 
 {% if site.agency_repos %}
 <section id="agency-repositories">
-  <h3 id="repositories">Agency-Centric</h3>
+  <h3 id="repositories">Agency-centric components</h3>  
   {% for agency in site.agency_repos %}
     <h4>{{agency.name}}</h4>
     {% include technology/repo_sublist.html repos=agency.repos %}

--- a/_includes/technology/stack.md
+++ b/_includes/technology/stack.md
@@ -1,9 +1,7 @@
-## Stack
+### Stack
 
-regulations-parser is written in Python 2.7.
+**regulations-parser** is written in Python 2.7.
 
-regulations-core is a Django and Haystack application.
+**regulations-core** is a Django and Haystack application.
 
-The regulations-site front-end is a Backbone.js application using Browserify. We also use a Grunt-based build system with Mocha for unit testing. On the back-end, regulations-site is a Django application.
-
-
+The **regulations-site** front-end is a Backbone.js application using Browserify. We also use a Grunt-based build system with Mocha for unit testing. On the back-end, **regulations-site** is a Django application.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -45,6 +45,8 @@
             and
             <a href="https://18f.gsa.gov">18F</a>.
           </p>
+          
+          <p><a href="https://github.com/eregs/eRegulations">Contribute to this documentation.</a></p>
 
           <p>Hosted on <a href="http://pages.github.com/">GitHub Pages</a>.</p>
         </div><!--/.wrap -->

--- a/_pages/features.md
+++ b/_pages/features.md
@@ -1,0 +1,39 @@
+---
+layout: default
+title: Features
+---
+# Features
+
+eRegulations includes an illustrated user guide that explains its features — see this live on [the CFPB eRegulations "About" page](http://www.consumerfinance.gov/eregulations/about) and [the ATF eRegulations "About" page](https://atf-eregs.apps.cloud.gov/about).
+
+In more detail, some of the main features of the tool are:
+
+- #### Navigability
+While regulations are traditionally represented as monolithic blocks of text, they contain a great deal of embedded structure. eRegulations teases out that structure and uses it to present the text in a clean, readable form.
+
+- #### Inline interpretations
+Many regulation paragraphs have official interpretations that have traditionally been displayed at the end of the regulation, forcing readers to swap back and forth between the regulation content and interpretation at the end. eRegulations parses the interpretations for each paragraph, and displays them right under the paragraph/section being interpreted.
+
+- #### Definitions
+We highlight words that have been defined in the regulation, and the user can click on the word and see it's definition without scrolling to the part of the regulation that defines that word.
+
+- #### Internal citations
+The parser parses out all internal citations in the regulation, and we display them as clickable links allowing easy navigation within a regulation.
+
+- #### Search
+We provide the ability to search for phrases across various versions of a regulation.
+
+- #### Alternate versions of the regulations
+Regulations are evolving documents and are often displayed as changes to the base text. We present whole versions of regulations for each set of changes (We combine Final Rules that have a common effective date into a version).
+
+- #### Comparing versions
+We show the difference between whole versions of regulations in a "redline" or word-by-word comparison view. All changes are expressed as additions (shown in green) or deletions (struck-through, lighter gray). This view clearly shows how a regulation changes.
+
+- #### Retrieve by effective date
+A user can also enter in a date, and retrieve the version of the regulation effective at that point in time.
+
+- #### Section-by-section analysis
+The notices that compose a version of the regulation contain relevant analyses of the altered sections. We automatically pull that information out and make it accessible while reading the regulation text.
+
+- #### Responsive design
+The application design is responsive, adjusting to the device and screen size of the user.

--- a/_pages/technology.md
+++ b/_pages/technology.md
@@ -3,7 +3,10 @@ layout: default
 title: Technology
 subtemplates: [architecture, stack, repos]
 ---
-# Technology
+# Code and documentation
+
+
+## How it works
 
 {% for subtemplate in page.subtemplates %}
   {% capture subtemplate_file %}technology/{{subtemplate}}.md{% endcapture %}
@@ -11,3 +14,8 @@ subtemplates: [architecture, stack, repos]
   {{ markdown | markdownify }}
 {% endfor %}
 
+## Open source and contributing
+
+We invite contributions to any part of the application, from people inside and outside government. The project is in the public domain, and all contributions to it will be released as such. By submitting a pull request, you are agreeing to waive all rights to your contribution under the terms of the [CC0 Public Domain Dedication](http://creativecommons.org/publicdomain/zero/1.0/).
+
+If you contribute the open source work of others, please mark it clearly in your pull request.


### PR DESCRIPTION
To help people understand eRegulations (including people at agencies curious about using the project, staff working on it, potential contributors, and members of the public), I rearranged and revised these pages.
- I rewrote the index page to be more of a landing page: a brief intro, an overview of the live instances, and summaries of the sub-pages (features, code/documentation, and introduction to regulations).
- I moved the detailed description of features to its own sub-page. The landing page still links prominently to the nice illustrated user guides on the CFPB and ATF eRegulations sites.
- I renamed the "Technology" page to "Code and documentation" to be more specific and help developers find the code faster.
- On the "Code and documentation" page: I bolded the repository names for clarity, I revised the explanation of the multiple repositories to be more direct (switching from passive to active voice), added a quick-start tip, renamed the sections to be more specific, and copied the landing page open source explanation to this page.
- I added a link to this documentation repository in the footer, for ease of editing.

This is a fairly major change with some rewriting of statements - I figured I'd throw in some experimental ideas, and I'd be happy to adjust or revert some of my changes!

This revision is part of working on https://github.com/18F/atf-eregs/issues/238 - helping users of ATF eRegulations find the relevant repositories and contribute to them if they like.
