### PR TITLE
Fixing mention of old section title

### DIFF
--- a/_includes/technology/repos.md
+++ b/_includes/technology/repos.md
@@ -1,6 +1,6 @@
 ## Repositories
 
-There are many individual repositories that make up eRegulations. The project is divided into several components, and currently CFPB and 18F maintain two separate forks of **regulations-parser**, **regulations-core**, and **regulations-site**. 18F and CFPB plan to eventually merge these forks into shared components with maintenance shared between multiple agencies. For now, in most cases people interested in using eRegulations should use the 18F repositories (listed under "General Purpose").
+There are many individual repositories that make up eRegulations. The project is divided into several components, and currently CFPB and 18F maintain two separate forks of **regulations-parser**, **regulations-core**, and **regulations-site**. 18F and CFPB plan to eventually merge these forks into shared components with maintenance shared between multiple agencies. For now, in most cases people interested in using eRegulations should use the 18F repositories.
 
 *Tip: If you'd like to get an example eRegulations site set up to try it out, check out [CFPB **regulations-bootstrap**](https://github.com/cfpb/regulations-bootstrap) to install a CFPB-centric version.*
 


### PR DESCRIPTION
I apparently renamed the "General Purpose" section without deleting a reference to that name, so here's a tiny fix for that. :)
