### PR TITLE
Update URLs to reflect the new docs repository location

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ eRegulations is a web-based tool that makes regulations easier to find, read
 and understand with features such as inline official interpretations,
 highlighted defined terms, and a revision comparison view. This repository
 contains companion documentation for the project and can be viewed at
-<http://eregs.github.io/eRegulations>
+<http://eregs.github.io/>
 
 ## Editing the documentation
 

--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ subtitle: Making regulations easily readable, accessible, and understandable.
 # When working locally use jekyll serve --baseurl '' so that you can view everything at localhost:4000
 # See http://jekyllrb.com/docs/github-pages/ for more info
 #baseurl: ''
-baseurl: '/eRegulations'
+baseurl: ''
 
 # Navigation
 # List links that should appear in the site sidebar here
@@ -68,8 +68,8 @@ general_repos:
       Often, source files will need to be massaged and modified to fit the
       parser's limited understanding. This repository is a canonical source
       for these edits, across all agencies, so that developers remain in sync.
-  - name: eRegulations
-    url: https://github.com/eregs/eRegulations
+  - name: eregs.github.io
+    url: https://github.com/eregs/eregs.github.io
     short: Documentation
     long: The content for these HTML pages.
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -46,7 +46,7 @@
             <a href="https://18f.gsa.gov">18F</a>.
           </p>
           
-          <p><a href="https://github.com/eregs/eRegulations">Contribute to this documentation.</a></p>
+          <p><a href="https://github.com/eregs/eregs.github.io">Contribute to this documentation.</a></p>
 
           <p>Hosted on <a href="http://pages.github.com/">GitHub Pages</a>.</p>
         </div><!--/.wrap -->


### PR DESCRIPTION
Reflecting the change from https://github.com/eregs/eRegulations to https://github.com/eregs/eregs.github.io in the README, the baseurl in _config.yml, the repo as listed in the docs, and the repo as linked from the bottom of each page.
