### PR TITLE
Add a Contact page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,6 +40,9 @@ navigation:
 - text: Introduction to regulations
   url: 'introduction/'
   internal: true
+- text: Contact
+  url: 'contact/'
+  internal: true
 
 
 general_repos:

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Contact
+---
+
+# Contact
+
+eRegulations is an [open source](/technology/#open-source-and-contributing)
+project with contributions from both individuals and agencies of the United
+States government. As such, general inquires and curiosities can be directed
+to the whole group by opening an
+[issue](https://github.com/eregs/eregs.github.io/issues/new) in our GitHub
+repository.
+
+That said, if you are interested in working with GSA's
+[18F](https://18f.gsa.gov) for hosting and customization, contact Will
+Sullivan at [will.sullivan@gsa.gov](mailto:will.sullivan@gsa.gov).


### PR DESCRIPTION
Agencies aren't sure how to contact anyone about the project. This describes
both a community contact method and an 18F contact method; we can add
additional contacts if desired.
