### PR TITLE
Add slack info, N&C playlist, OMB

### DIFF
--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -10,11 +10,15 @@ project with contributions from both individuals and agencies of the United
 States government. As such, general inquires and curiosities can be directed
 to the whole group by opening an
 [issue](https://github.com/eregs/eregs.github.io/issues/new) in our GitHub
-repository.
+repository. GSA's [18F](https://18f.gsa.gov) also hosts a Slack channel that's
+open to the public; join by filling out the [requested
+information](https://chat.18f.gov/) and selecting "eRegulations" as your
+topic.
 
-That said, if you are interested in working with GSA's
-[18F](https://18f.gsa.gov) for hosting and customization, contact Will
-Sullivan at [will.sullivan@gsa.gov](mailto:will.sullivan@gsa.gov) or [eregs@gsa.gov](mailto:eregs@gsa.gov).
+If you are interested in working with 18F for hosting and customization of an
+eRegs instance, contact Will Sullivan at
+[will.sullivan@gsa.gov](mailto:will.sullivan@gsa.gov) or
+[eregs@gsa.gov](mailto:eregs@gsa.gov).
 
 # Governance
 

--- a/_pages/features/notice-and-comment.md
+++ b/_pages/features/notice-and-comment.md
@@ -15,6 +15,8 @@ Agency’s eManifest team.
  
 ## Sprint demo playlist (11 videos)
 
-<iframe width="560" height="315"
-src="https://www.youtube.com/embed/videoseries?list=PLd9b-GuOJ3nHSz3GVv0UsOtDCxlaVdtj2"
-frameborder="0" allowfullscreen></iframe>
+<div class="youtube-wrapper">
+  <iframe
+  src="https://www.youtube.com/embed/videoseries?list=PLd9b-GuOJ3nHSz3GVv0UsOtDCxlaVdtj2"
+  frameborder="0" allowfullscreen></iframe>
+</div>

--- a/_pages/features/notice-and-comment.md
+++ b/_pages/features/notice-and-comment.md
@@ -12,12 +12,9 @@ agencies to more easily manage and contextually organize the comments coming
 in. The pilot project launches in mid-July with the Environmental Protection
 Agency’s eManifest team.
 
+ 
+## Sprint demo playlist (11 videos)
 
-## Links to demo videos
-
-* [Sprint 1](https://www.youtube.com/watch?v=w9LCTExyC3A)
-* [Sprint 2](https://www.youtube.com/watch?v=vH6UznuKyu0)
-* [Sprint 3 - First Wireframes!](https://www.youtube.com/watch?v=7aEjjk-JrKg)
-* [Sprint 4 - More Wireframes!](https://www.youtube.com/watch?v=wFEDa7CsQAo)
-* [Sprint 5 - Wireframes &amp; Working Code!](https://www.youtube.com/watch?v=h8DyhPOgUt4)
-
+<iframe width="560" height="315"
+src="https://www.youtube.com/embed/videoseries?list=PLd9b-GuOJ3nHSz3GVv0UsOtDCxlaVdtj2"
+frameborder="0" allowfullscreen></iframe>

--- a/_pages/story.md
+++ b/_pages/story.md
@@ -58,6 +58,10 @@ A few examples:
 * [ATF](https://www.atf.gov/rules-and-regulations) publishes "rulings" and "open letters" that clarify aspects of its regulations. It also publishes plain-language Q&As, newsletters, and guidebooks to help explain its regulations. ATF's eRegulations only has a small amount of cross-linking with related resources, and it could do a lot more in the future.
 * [FEC](http://www.fec.gov/law/law.shtml) publishes "advisory opinions" and "Matters Under Review" that clarify aspects of its regulations, among other kinds of material.
 
+Relatedly, we've recently kicked off [an
+effort](https://github.com/18F/omb-eregs) to apply eRegs learnings to the
+Office of Management and Budget's policy documents. 
+
 ## How it works
 
 [Code and documentation](../technology/) explains this in more detail, but in short: the parser eats XML from many different sources and writes that to an API. The UI then reads from that API.

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -578,3 +578,20 @@ Mobile Styles
     }
 
 }
+
+/* See
+ * https://www.h3xed.com/web-development/how-to-make-a-responsive-100-width-youtube-iframe-embed
+ **/
+.youtube-wrapper {
+  position: relative;
+  width: 100%;
+  height: 0;
+  padding-bottom: 56.25%;
+}
+.youtube-wrapper iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
References the 18F slack room, embeds an iframe for the Notice & Comment demos playlist, and references the OMB repository. May expand the latter once we have a better sense of that project.