### PR TITLE
Remove mention of specific Python version

### DIFF
--- a/_includes/technology/stack.md
+++ b/_includes/technology/stack.md
@@ -1,6 +1,6 @@
 ### Stack
 
-**regulations-parser** is written in Python 2.7.
+**regulations-parser** is written in Python.
 
 **regulations-core** is a Django and Haystack application.
 


### PR DESCRIPTION
Specifying Python 2.7 gave the wrong impression that this project does
not support Python3. Not specifying a version would indicate support for
several versions.