### PR TITLE
Update URLs for live instances

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -166,12 +166,12 @@ brand_color: "#2cb34a"
 
 # eRegs instances in the wild
 instances:
-- url: https://www.fec.gov/legal-resources/regulations/
+- url: hhttps://www.fec.gov/regulations
   title: 11
   agency: Federal Election Commission
-- url: http://www.consumerfinance.gov/eregulations/
+- url: https://www.consumerfinance.gov/rules-policy/regulations/
   title: 12
   agency: Consumer Financial Protection Bureau
-- url: https://atf-eregs.app.cloud.gov/
+- url: https://regulations.atf.gov/
   title: 27
   agency: Bureau of Alcohol, Tobacco, Firearms and Explosives

--- a/_config.yml
+++ b/_config.yml
@@ -166,7 +166,7 @@ brand_color: "#2cb34a"
 
 # eRegs instances in the wild
 instances:
-- url: hhttps://www.fec.gov/regulations
+- url: https://www.fec.gov/regulations
   title: 11
   agency: Federal Election Commission
 - url: https://www.consumerfinance.gov/rules-policy/regulations/


### PR DESCRIPTION
* Switched ATF eRegs to its ATF.gov URL
* Updated CFPB link to the place that the old link redirected to
* Made the FEC link go directly to its eRegs instance